### PR TITLE
Tables to end of document

### DIFF
--- a/.assets/templates/_draft.tex
+++ b/.assets/templates/_draft.tex
@@ -3,6 +3,8 @@
 \usepackage{lineno}
 \usepackage[nolists,noheads]{endfloat}
 
+\DeclareDelayedFloatFlavour*{longtable}{table}
+
 \pagestyle{plain}
 
 \tolerance=1


### PR DESCRIPTION
This suggested change will also send table to the end of the document for the draft PDF (same as for figures). Simply it takes the longtable object and turns it back to a float which then plays nicely with endfloat. For an example see here: https://poisotlab.github.io/ms_metaweb_perspectives/draft.pdf