### PR TITLE
Allow for author names with white spaces

### DIFF
--- a/.assets/scripts/filename.jl
+++ b/.assets/scripts/filename.jl
@@ -25,6 +25,7 @@ else
 end
 
 filename = join([author_string, ms_year, title_placeholder], "_")
+filename = filter(x -> !isspace(x), filename)
 
 open("filename", "w") do f
     return write(f, filename)


### PR DESCRIPTION
Fixed `filename.jl` so that it can handle author family names with white spaces.

It does that by stripping all white spaces in the filename.

The fix solves an issues with pandoc, that would result in a `file not found error`.